### PR TITLE
[✨ Feat] Auth로 user 정보 조회 API 구현

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/main/java/org/refit/spring/auth/dto/UserResponseDto.java
+++ b/src/main/java/org/refit/spring/auth/dto/UserResponseDto.java
@@ -1,0 +1,28 @@
+package org.refit.spring.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.refit.spring.auth.entity.User;
+
+
+@Getter
+@AllArgsConstructor
+public class UserResponseDto {
+    private Long userId;
+    private String role;
+    private String name;
+    private String birthDate;
+    private Long totalCarbonPoint;
+    private Long totalStarPoint;
+
+    public static UserResponseDto from(User user) {
+        return new UserResponseDto(
+                user.getUserId(),
+                user.getRole().name(),
+                user.getName(),
+                user.getBirthDate(),
+                user.getTotalCarbonPoint(),
+                user.getTotalStarPoint()
+        );
+    }
+}

--- a/src/main/java/org/refit/spring/auth/entity/User.java
+++ b/src/main/java/org/refit/spring/auth/entity/User.java
@@ -3,16 +3,23 @@ package org.refit.spring.auth.entity;
 import lombok.*;
 import org.refit.spring.auth.enums.UserRole;
 
+import java.time.LocalDate;
+
 @Data
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class User {
-    private Long id;
+    private Long userId;
     private String username;
     private String password;
     private String name;
+    private String birthDate;
+    private Long totalCarbonPoint;
+    private Long totalStarPoint;
     //enum으로 사업자/일반유저 분리
     private UserRole role;
     private String refreshToken;
+    private LocalDate createdAt;
+    private LocalDate updatedAt;
 }

--- a/src/main/java/org/refit/spring/auth/repository/userRepository.java
+++ b/src/main/java/org/refit/spring/auth/repository/userRepository.java
@@ -1,4 +1,0 @@
-package org.refit.spring.auth.repository;
-
-public class userRepository {
-}

--- a/src/main/java/org/refit/spring/auth/service/UserService.java
+++ b/src/main/java/org/refit/spring/auth/service/UserService.java
@@ -1,0 +1,16 @@
+package org.refit.spring.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.refit.spring.auth.entity.User;
+import org.refit.spring.mapper.UserMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserMapper userMapper;
+
+    public User findByUsername(String username) {
+        return userMapper.findByUsername(username);
+    }
+}

--- a/src/main/java/org/refit/spring/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/refit/spring/security/jwt/JwtTokenProvider.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
@@ -43,6 +44,14 @@ public class JwtTokenProvider {
     public String getUsername(String token) {
         return Jwts.parserBuilder().setSigningKey(secretKey.getBytes()).build()
                 .parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8))
+                .parseClaimsJws(token)
+                .getBody();
+        return Long.parseLong(claims.get("userId").toString());
     }
 
     public Authentication getAuthentication(String token) {

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -3,11 +3,11 @@
         PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-config.dtd">
 <configuration>
+    <settings>
+        <setting name="mapUnderscoreToCamelCase" value="true"/>
+    </settings>
     <typeHandlers>
         <typeHandler handler="org.refit.spring.auth.enums.UserRoleTypeHandler"
                      javaType="org.refit.spring.auth.enums.UserRole"/>
     </typeHandlers>
-<!--    <typeAliases>-->
-
-<!--    </typeAliases>-->
 </configuration>


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
https://github.com/KB-PBL-GGABEES/kb_refit_server/issues/5

## 📌 개요
- 로그인에 성공했을 때 발급되는 accessToken을 헤더에 담아 오쳥을 했을 때 해당 accessToken의 주인의 정보를 조회하는 API입니다.

## 🔁 변경 사항

## 📸 스크린샷
- 테스트 성공한 스크린샷은 노션 API 명세서에 올려주세요

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
